### PR TITLE
Add depmedic ci-doctor family (GitHub Actions + 4 sister CIs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,8 @@ comparison on Wikipedia.
 
 To the extent possible under law, [Sergey Bronnikov](https://bronevichok.ru) has
 waived all copyright and related or neighboring rights to this work.
+
+
+## Cloud / Hosted
+
+- [ci-doctor](https://github.com/depmedicdev-byte/ci-doctor) - Audits GitHub Actions workflows for cost waste, security gaps, and reliability issues. 16 rules, SARIF + PR comment via companion Action. Sister CLIs cover GitLab CI, Bitbucket Pipelines, Azure Pipelines, CircleCI.


### PR DESCRIPTION
### What this adds

> - [ci-doctor](https://github.com/depmedicdev-byte/ci-doctor) - Audits GitHub Actions workflows for cost waste, security gaps, and reliability issues. 16 rules, SARIF + PR comment via companion Action. Sister CLIs cover GitLab CI, Bitbucket Pipelines, Azure Pipelines, CircleCI.

### Why

depmedic ships a family of CI cost+security auditors covering GitHub, GitLab, Bitbucket, Azure Pipelines, and CircleCI. Each is a single-binary `npx` invocation, MIT, no telemetry, with SARIF + PR comment integration. They are well-tested (3-5 `node --test` suites each), versioned, and actively maintained.

### Conformance

- One line per entry in alphabetical order within the section
- Description starts with a verb (Audit / Audits)
- Trailing period on the description
- Link target is the canonical repo URL

Happy to adjust wording, ordering, or section placement; ping me on this PR.

---

If you'd rather decline, no hard feelings. Thanks for the list.