### PR TITLE
Add BreakShield CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ comparison on Wikipedia.
 
 To the extent possible under law, [Sergey Bronnikov](https://bronevichok.ru) has
 waived all copyright and related or neighboring rights to this work.
+- [BreakShield CI](https://breakshield-ci.vercel.app) - Detects breaking API changes in PRs using TypeScript AST analysis. AI auto-fix via /fix command. Free, open-source.


### PR DESCRIPTION
Adding BreakShield CI — a CI tool focused on API contract validation. It analyzes every PR for breaking changes using TypeScript AST diffing and posts findings with confidence levels.

Free, open-source, runs as a GitHub App. No self-hosting required.

https://breakshield-ci.vercel.app
https://github.com/vojtisprime11/BreakShield